### PR TITLE
Fix sending message when bot is not found

### DIFF
--- a/whatsapp-server/server.js
+++ b/whatsapp-server/server.js
@@ -226,6 +226,8 @@ async function handleIncomingMessage(sock, integrationId, m) {
         // Stop typing indicator
         await sock.sendPresenceUpdate('paused', sender)
 
+        if (response.status === 404) return;
+
         // Send the response back to the sender
         if (responseData.response) {
             await sock.sendMessage(sender, { text: responseData.response })


### PR DESCRIPTION
The WhatsApp server always sends a message when the bot is not found, which can cause a message loop if the receiver has auto-reply enabled.