### PR TITLE
fix(container) : add generate app key

### DIFF
--- a/docker/sail/start-container
+++ b/docker/sail/start-container
@@ -30,6 +30,14 @@ else
     gosu $WWWUSER npm install
 fi
 
+#Run key Generate
+echo "Generating application key..."
+if ["${SUPERVISOR_PHP_USER}" = "root"]; then
+    php artisan key:generate
+else
+    gosu $WWWUSER php artisan key:generate
+fi
+
 # Run migrations and seeders
 echo "Running migrations and seeders..."
 if [ "$SUPERVISOR_PHP_USER" = "root" ]; then


### PR DESCRIPTION
This pull request adds functionality to generate an application key during the container startup process in the `docker/sail/start-container` file.

Key generation addition:

* Added a conditional block to generate the application key using `php artisan key:generate`. The command is executed either as the root user or as the `$WWWUSER` user, depending on the value of the `SUPERVISOR_PHP_USER` environment variable.