### PR TITLE
fix(CRLF to LF) : fix formatting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,4 @@
-* text=auto
-
+* text=auto eol=lf
 *.blade.php diff=html
 *.css diff=css
 *.html diff=html


### PR DESCRIPTION
This pull request updates the `.gitattributes` file to ensure consistent line endings across the repository.

File configuration changes:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eL1-R1): Added `eol=lf` to the `* text=auto` rule to enforce LF (line feed) as the line ending format for all text files.

this will fix #32