### PR TITLE
Fix issue crlf on windows docker 

### DIFF
--- a/docker/mysql/create-testing-database.sh
+++ b/docker/mysql/create-testing-database.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env
 
 mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS testing;

--- a/docker/mysql/create-whatsapp-database.sh
+++ b/docker/mysql/create-whatsapp-database.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env
 
 mysql --user=root --password="$MYSQL_ROOT_PASSWORD" <<-EOSQL
     CREATE DATABASE IF NOT EXISTS \`${WA_DB_DATABASE}\`;

--- a/docker/sail/start-container
+++ b/docker/sail/start-container
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env
 
 if [ "$SUPERVISOR_PHP_USER" != "root" ] && [ "$SUPERVISOR_PHP_USER" != "sail" ]; then
     echo "You should set SUPERVISOR_PHP_USER to either 'sail' or 'root'."


### PR DESCRIPTION
This pull request makes minor changes to several shell script files within the `docker` directory by removing the `bash` interpreter specification from the shebang line. These updates ensure compatibility with environments where `bash` might not be the default shell.

Affected files:

* [`docker/mysql/create-testing-database.sh`](diffhunk://#diff-9bc17493fca526d488d3564b0d4a89b48591a95916beae5eefa68eeedf643f8eL1-R1): Updated the shebang line to remove `bash`.
* [`docker/mysql/create-whatsapp-database.sh`](diffhunk://#diff-4bfb78b23c21138cccc1fd4167b996d7a422033db04e874b0c25b404953999c1L1-R1): Updated the shebang line to remove `bash`.
* [`docker/sail/start-container`](diffhunk://#diff-14776c1a863be67f3618863f1426b76ee9a20dda5e18be368b3eddac28434f4aL1-R1): Updated the shebang line to remove `bash`.

Ref issue: #32 