### PR TITLE
Fix error message was not displayed

### DIFF
--- a/app/Console/Commands/WhatsAppStartServer.php
+++ b/app/Console/Commands/WhatsAppStartServer.php
@@ -19,6 +19,8 @@ class WhatsAppStartServer extends Command
             ->run(['node', base_path('whatsapp-server/server.js'), $storagePath], function ($type, $output) {
                 if ($type === 'out') {
                     $this->output->write($output);
+                } elseif ($type === 'err') {
+                    $this->output->error($output);
                 }
             });
     }


### PR DESCRIPTION
Running `php artisan whatsapp:start` resulted in an error, but the error was not displayed.

<img width="1229" height="621" alt="Screenshot 2025-09-05 at 18 35 56" src="https://github.com/user-attachments/assets/7911235f-4944-4348-9aae-c2ec704714cb" />
